### PR TITLE
Support specific model

### DIFF
--- a/src/Console/AbstractCommand.php
+++ b/src/Console/AbstractCommand.php
@@ -53,7 +53,7 @@ abstract class AbstractCommand extends Command
 
         // Process all provided models
         foreach ($this->getModelArgument() as $model) {
-            if ($model = $this->validateModel("{$this->models}\\{$model}")) {
+            if ($model = $this->validateModel($model)) {
 
                 // Get model instance
                 $instance = new $model();
@@ -110,6 +110,10 @@ abstract class AbstractCommand extends Command
             $model = array_map(function ($m) {
                 return Str::studly($m);
             }, explode('\\', $model));
+
+            if (!empty($model[0])) {
+                $model = array_merge([$this->models], $model);
+            }
 
             return implode('\\', $model);
         }, $models);


### PR DESCRIPTION
### Problem: 
The config only support 1 namespace, and in my project, I have 2 namespaces for models.

1. App
2. Applications\Models

config was setup model namespace = `\\App`, so mean I can't switch to other namespace.

### Solution:
Get full namespace(specific model), mean no need to using config model namespace.

Hope this PR can solve specific model issues

Command:

```shell
php artisan Media,\\Applications\\Models\\Media,Models\\Media
```

Get Model array is
```
array:2 [
  0 => "\App\Media"
  1 => "\Applications\Models\Media"
  2 => "\App\Models\Media"
]
```

